### PR TITLE
Adding a "production" build

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -18,6 +18,10 @@ gulp.task('serve', ['nodemon', 'sass'], function() {
     gulp.watch(PATHS.html).on('change', browserSync.reload);
 });
 
+gulp.task('production', ['sass'], function(){
+    require('./src/server.js');
+})
+
 gulp.task('sass', function() {
    return gulp.src(PATHS.sass)
         .pipe(sass())

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -17,12 +17,7 @@ gulp.task('serve', ['nodemon', 'sass'], function() {
   gulp.watch(PATHS.html).on('change', browserSync.reload);
 });
 
-gulp.task('production', function(){
-  gulp.src(PATHS.sass)
-    .pipe(sass())
-    .pipe(gulp.dest("dist"));
-  require('./src/server.js');
-});
+gulp.task('build', ['sass']);
 
 gulp.task('sass', function() {
   return gulp.src(PATHS.sass)

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,24 +9,23 @@ var PATHS = {
 };
 
 gulp.task('serve', ['nodemon', 'sass'], function() {
+  browserSync.init({
+    proxy: 'localhost:4200'
+  });
 
-    browserSync.init({
-      proxy: 'localhost:4200'
-    });
-
-    gulp.watch(PATHS.sass, ['sass']);
-    gulp.watch(PATHS.html).on('change', browserSync.reload);
+  gulp.watch(PATHS.sass, ['sass']);
+  gulp.watch(PATHS.html).on('change', browserSync.reload);
 });
 
 gulp.task('production', ['sass'], function(){
-    require('./src/server.js');
+  require('./src/server.js');
 })
 
 gulp.task('sass', function() {
-   return gulp.src(PATHS.sass)
-        .pipe(sass())
-        .pipe(gulp.dest("dist"))
-        .pipe(browserSync.stream());
+  return gulp.src(PATHS.sass)
+    .pipe(sass())
+    .pipe(gulp.dest("dist"))
+    .pipe(browserSync.stream());
 });
 
 gulp.task('nodemon', function () {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -17,9 +17,12 @@ gulp.task('serve', ['nodemon', 'sass'], function() {
   gulp.watch(PATHS.html).on('change', browserSync.reload);
 });
 
-gulp.task('production', ['sass'], function(){
+gulp.task('production', function(){
+  gulp.src(PATHS.sass)
+    .pipe(sass())
+    .pipe(gulp.dest("dist"));
   require('./src/server.js');
-})
+});
 
 gulp.task('sass', function() {
   return gulp.src(PATHS.sass)

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "gulp serve",
+    "start:prod": "sudo systemctl start sexxi.xyz",
     "build": "gulp build"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "A very sexxi website for SEXXIs",
   "main": "index.js",
   "scripts": {
-    "start": "gulp serve"
+    "start": "gulp serve",
+    "build": "gulp build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
For when you want to serve it without all the browsersync-ey stuff. Gulp just makes so much natural sense that I didn't even need to "learn" it. <3

In package.json, I'm not sure whether stuff like Sass would be considered as devDependencies or as plain old dependencies, since when you clone the repo you'll still need them anyway to build the production version. I'm sure there's standard convention on this issue, just don't know what it is. Thoughts?
