### PR TITLE
Seems more extensible to use npm test

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,10 +9,11 @@
     "build": "gulp build",
     "lint": "gulp lint",
     "lint:sass": "gulp lint-sass",
-    "lint:pug": "gulp lint-pug"
+    "lint:pug": "gulp lint-pug",
+    "test": "npm lint"
   },
   "pre-commit": [
-    "lint"
+    "test"
   ],
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "gulp lint",
     "lint:sass": "gulp lint-sass",
     "lint:pug": "gulp lint-pug",
-    "test": "npm lint"
+    "test": "npm run lint"
   },
   "pre-commit": [
     "test"


### PR DESCRIPTION
Seems more extensible to use npm test (if we want to add mocha et al later), so that we can make fewer changes to the structure of the package.json.
