### PR TITLE
Fonts

### DIFF
--- a/src/assets/styles/style.sass
+++ b/src/assets/styles/style.sass
@@ -1,7 +1,8 @@
 body>header
+  font-family: Arial
   font-size: 1.5vw
-  margin-top: -4.5em
-  padding: 35vh 2em 0
+  margin-top: -4.5em  //Clever trick with fixed margin and percentage padding
+  padding: 33vh 2em 0 // to achieve desired scaling on mobile and desktop
   text-align: center
 
   p
@@ -10,11 +11,13 @@ body>header
 
   h1
     font-size: 12em
-    line-height: 1em
-    margin: 0
+    margin: -0.2em 0 -0.1em
+    padding: 0
 
     .se
       font-weight: 900
 
     .xxi
+      font-family: Georgia
       font-weight: 100
+      font-size: 1.03em //Compensate for Georgia and Arial height difference

--- a/src/views/index.pug
+++ b/src/views/index.pug
@@ -1,11 +1,12 @@
 doctype html
 html(lang='en')
   head
-    title= 'SE XXI'
     meta(charset='utf-8')
     meta(name='description', content='SEXXI: Waterloo Software Engineering Class of 2021')
     meta(name='viewport' content='width=device-width, initial-scale=1, user-scalable=yes')
     meta(name='author' content='Waterloo SE 2021')
+
+    title= 'SE XXI'
 
     link(href='static/style.css' rel='stylesheet')
 


### PR DESCRIPTION
Serif for XXI, sans-serif for the rest. Looks good.

I kind of want to use the fonts here:
https://uwaterloo.ca/brand-guidelines-and-tools/visual-identity/typography
But they're pay-to-use. Montserrat (a free Google Font) is similar to Gotham, and Le Monde looks like a reasonably generic serif.
